### PR TITLE
修改package.json中main指向dist/baidubce-sdk.bundle.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@baiducloud/sdk",
   "version": "1.0.0-rc.1",
   "description": "Baidu Cloud Engine JavaScript SDK",
-  "main": "index.js",
+  "main": "dist/baidubce-sdk.bundle.js",
   "directories": {
     "test": "test"
   },


### PR DESCRIPTION
解决通过import {BosClient} from '@baidubce/sdk'时依然会经过不合适的browserify版本编译src下的源码引起[#53](https://github.com/baidubce/bce-sdk-js/issues/53)