### PR TITLE
chore:浏览器版本默认引用用压缩版本

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "browser": {
     "fs": false,
     "net": "./src/browser/net.js",
-    "index.js": "./dist/baidubce-sdk.bundle.js"
+    "index.js": "./dist/baidubce-sdk.bundle.min.js"
   },
   "files": [
     "dist/",


### PR DESCRIPTION
项目中通过npm引用，发现打包后bce-sdk-js包比较大， 希望默认使用压缩版本